### PR TITLE
Allowed having unlisted modifiers

### DIFF
--- a/app/models/search-context.ts
+++ b/app/models/search-context.ts
@@ -1,6 +1,7 @@
 import { computed, set } from '@ember/object';
 
 interface RawModifier {
+  unlisted?: boolean;
   hint: string;
   modifier: string;
   title: string;
@@ -17,11 +18,14 @@ export default class SearchContext {
   @computed('modifiers.[]')
   public get config(): ConfigMap {
     let config: ConfigMap = {};
-    this.modifiers.forEach(({ modifier, hint, title, values }) => {
+    this.modifiers.forEach((rawModifier) => {
+      let { modifier, hint, title, values } = rawModifier;
+      let unlisted = !!rawModifier.unlisted;
       if (modifier !== '#') { modifier = `${modifier}:`; }
       config[modifier] = {
         content: values,
         defaultHint: hint,
+        unlisted,
         sectionTitle: title,
         type: 'list'
       };

--- a/app/utils/search.ts
+++ b/app/utils/search.ts
@@ -65,11 +65,12 @@ export function getDefaultContent(configMap: ConfigMap, modifiersList: Modifier[
   return modifiers.concat(allList);
 }
 
-export function getAllModifiers(configMap: ConfigMap): Modifier[] {
+export function getAllModifiers(configMap: ConfigMap, onlyVisible: boolean=false): Modifier[] {
   let modifiers: Modifier[] = [];
   for (let key in configMap) {
     if (configMap.hasOwnProperty(key)) {
       const config = configMap[key];
+      if (onlyVisible && config.unlisted) { continue; }
       const section = config.type === 'date' ? 'time' : 'others';
       modifiers.push({
         label: config.defaultHint,
@@ -84,10 +85,9 @@ export function getAllModifiers(configMap: ConfigMap): Modifier[] {
 
 export function prepareConfig(configMap: ConfigMap): ConfigMap {
   configMap = deepClone(configMap);
-  const modifiers = getAllModifiers(configMap);
-  configMap['+'] = { type: 'modifier-list', content: modifiers };
+  configMap['+'] = { type: 'modifier-list', content: getAllModifiers(configMap, true) };
   configMap._default = {
-    content: getDefaultContent(configMap, modifiers),
+    content: getDefaultContent(configMap, getAllModifiers(configMap)),
     type: 'default'
   };
   return configMap;

--- a/types/search-with-modifiers/index.d.ts
+++ b/types/search-with-modifiers/index.d.ts
@@ -24,6 +24,7 @@ declare global {
   interface SearchContextConfig {
     content: Hint[];
     defaultHint?: string;
+    unlisted?: boolean;
     sectionTitle?: string;
     type: string;
   }


### PR DESCRIPTION
### Summary
Unlisted modifiers are not suggested in the special `+` token, but _can_ still be autocompleted if the user types them out.