### PR TITLE
Added Babel polyfill for IE 11 explicitly

### DIFF
--- a/config/targets.js
+++ b/config/targets.js
@@ -1,5 +1,8 @@
 'use strict';
 
+// Production detection seems to be slightly
+// unreliable. Just comment out 'ie 11' when
+// developing to make it easier to trace errors.
 const browsers = [
   'last 1 Chrome versions',
   'last 1 Firefox versions',

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -7,6 +7,9 @@ module.exports = function(defaults) {
     babel: {
       sourceMaps: 'inline',
     },
+    'ember-cli-babel': {
+      includePolyfill: true,
+    },
 
     storeConfigInMeta: false
   });


### PR DESCRIPTION
### Summary
~~Detection of building for production seems hit-or-miss, so we'll just always include building for IE11. The motivation behind optionally excluding it is that it makes the code much more straightforward to debug during development, as there's less difference between the code you write and the code after it's built. But it's just as easy to turn off targeting IE 11 while developing and not committing that change if it assures us that IE will continue to work in production.~~

We needed to enable the Babel polyfills 🤦‍♂ 