### PR TITLE
Restored the "Narrow Your Search" section heading to modifiers

### DIFF
--- a/app/utils/search.ts
+++ b/app/utils/search.ts
@@ -58,11 +58,7 @@ export function getDefaultContent(configMap: ConfigMap, modifiersList: Modifier[
       }
     }
   }
-  const modifiers = modifiersList.map(function(item: Modifier) {
-    item.section = 'Narrow your Search';
-    return item;
-  });
-  return modifiers.concat(allList);
+  return modifiersList.concat(allList);
 }
 
 export function getAllModifiers(configMap: ConfigMap, onlyVisible: boolean=false): Modifier[] {
@@ -71,7 +67,7 @@ export function getAllModifiers(configMap: ConfigMap, onlyVisible: boolean=false
     if (configMap.hasOwnProperty(key)) {
       const config = configMap[key];
       if (onlyVisible && config.unlisted) { continue; }
-      const section = config.type === 'date' ? 'time' : 'others';
+      const section = config.type === 'date' ? 'time' : 'Narrow your Search';
       modifiers.push({
         label: config.defaultHint,
         modifier: true,


### PR DESCRIPTION
This was a side-effect brought to light by the changes made to allow "unlisting" certain modifiers. When preparing default content, instead of modifying _copies_ of each modifier, changing the section name, we were modifying the original objects, so the special `+` token/modifier ended up getting the changes in its modifiers, as well. But with unlisting, the general content list and the `+` modifier contained separate objects, meaning the `+`'s modifier list now _didn't_ get this behind-the-scenes modification. This PR essentially drops the indirection and assigns "Narrow your Search" as the section when generating modifiers in the first place.