### PR TITLE
Turbolinks support

### DIFF
--- a/app/components/search-with-modifiers.ts
+++ b/app/components/search-with-modifiers.ts
@@ -127,19 +127,28 @@ export default class SearchWithModifiers extends Component {
       });
     }
 
-    if (!this.query) {
-      const queryMatch = window.location.search.match(/q=([^&]+)/);
-      const query = queryMatch ? decodeURIComponent(queryMatch[1]) : '';
-      this.set('query', query);
-    }
+    if (!this.query) { this.pullQueryFromLocation(); }
   }
 
   didInsertElement() {
     window.addEventListener('click', this.clickAwayHandler);
+    window.addEventListener('turbolinks:load', this.turbolinksLoadHandler);
   }
 
   willDestroyElement() {
     window.removeEventListener('click', this.clickAwayHandler);
+    window.removeEventListener('turbolinks:load', this.turbolinksLoadHandler);
+  }
+
+  pullQueryFromLocation() {
+    const queryMatch = window.location.search.match(/q=([^&]+)/);
+    const query = queryMatch ? decodeURIComponent(queryMatch[1]) : '';
+    this.setProperties({ query, cachedQuery: query });
+  }
+
+  @action
+  turbolinksLoadHandler() {
+    this.pullQueryFromLocation();
   }
 
   @action


### PR DESCRIPTION
Should still be compatible with non-turbolinks pages, as the event will simply never be fired.

**NB:** Because `_query` is calculated based on both `query` and `cachedQuery`, we have to set both when updating based on the location href, otherwise `_query` will be counted as being modified twice: once recalculated based on a change in `query` and once based on `cachedQuery` getting updated (by `search-box` when its input's value is changed).