### PR TITLE
Bumped xmldom to 0.7.0 to address CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "printf": "^0.6.1",
     "set-value": "^3.0.1",
     "union-value": "^2.0.0",
+    "xmldom": "github:xmldom/xmldom#0.7.0",
     "xmlhttprequest-ssl": "^1.6.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8935,10 +8935,9 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
-xmldom@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.6.0.tgz#43a96ecb8beece991cef382c08397d82d4d0c46f"
-  integrity sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==
+xmldom@^0.6.0, "xmldom@github:xmldom/xmldom#0.7.0":
+  version "0.7.0"
+  resolved "https://codeload.github.com/xmldom/xmldom/tar.gz/c568938641cc1f121cef5b4df80fcfda1e489b6e"
 
 xmlhttprequest-ssl@^1.6.2, xmlhttprequest-ssl@~1.5.4:
   version "1.6.2"


### PR DESCRIPTION
### Summary
It would seem that the xmldom team is unable to publish this version to npm for some reason, so we'll use the code from GH. (cf. https://github.com/xmldom/xmldom/issues/271) We'll have to switch this back to using the version number once that issue is resolved.