### PR TITLE
Resolved ansi-html to maintained community package for CVE

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "resolutions": {
     "acorn": "^6.4.1",
+    "ansi-html": "mahdyar/ansi-html-community#v0.0.8",
     "clean-css": "^4.1.11",
     "lodash.template": "^4.5.0",
     "minimist": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,10 +1563,9 @@ ansi-escapes@^3.0.0, ansi-escapes@^3.2.0:
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
-ansi-html@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/ansi-html/-/ansi-html-0.0.7.tgz#813584021962a9e9e6fd039f940d12f56ca7859e"
-  integrity sha1-gTWEAhliqenm/QOflA0S9WynhZ4=
+ansi-html@^0.0.7, ansi-html@mahdyar/ansi-html-community#v0.0.8:
+  version "0.0.8"
+  resolved "https://codeload.github.com/mahdyar/ansi-html-community/tar.gz/f87d7a2f6062de7d98f02a93f90c81adba68fef1"
 
 ansi-regex@^2.0.0:
   version "2.1.1"


### PR DESCRIPTION
### Summary
`ansi-html` is apparently unmaintained, hence pointing to the forked version in GitHub